### PR TITLE
initialize $do_compress

### DIFF
--- a/lib/RPC/XML/Server.pm
+++ b/lib/RPC/XML/Server.pm
@@ -841,6 +841,7 @@ sub process_request ## no critic (ProhibitExcessComplexity)
             # Get a XML::Parser::ExpatNB object
             $parser = $self->parser->parse();
 
+            $do_compress = 0; # in case it was set for a previous response
             if (($req->content_encoding || q{}) =~ $self->compress_re)
             {
                 if (! $self->compress)


### PR DESCRIPTION
If the server sends a compressed response, $do_compress remains set to 1 for the next request.  So the server always tries to uncompress the next request, even when it's not really compressed (which causes it to fail).  This initializes $do_compress = 0 before checking the request for compression.
