### PR TITLE
Make the build reproducible by dropping timestamps in make_method output

### DIFF
--- a/etc/make_method
+++ b/etc/make_method
@@ -363,7 +363,6 @@ sub write_file
         }
     }
 
-    my $date = scalar localtime;
     my %typemap = (
         'm' => 'method',
         p   => 'procedure',
@@ -399,7 +398,7 @@ sub write_file
 <?xml version="1.0" encoding="iso-8859-1"?>
 <!DOCTYPE $tag SYSTEM "rpc-method.dtd">
 <!--
-    Generated automatically by $cmd $VERSION on $date
+    Generated automatically by $cmd $VERSION
 
     Any changes made here will be lost.
 -->


### PR DESCRIPTION
While working on Debian's “reproducible builds” effort [1], we have noticed that librpc-xml-perl doesn't build reproducibly.
The tool make_method adds timestamps into the comment of generated XML files.

[1] https://wiki.debian.org/ReproducibleBuilds 

Please consider this fix by Reiner Herrmann <reiner@reiner-h.de>.