### PR TITLE
In Perl regular expressions, \d matches any digit in any alphabet. Bu…

### DIFF
--- a/lib/RPC/XML.pm
+++ b/lib/RPC/XML.pm
@@ -268,7 +268,7 @@ sub time2iso8601
             # You have to check ints first, because they match the
             # next pattern (for doubles) too
             elsif (! $FORCE_STRING_ENCODING &&
-                   /^[-+]?\d+$/ &&
+                   /^[-+]?\d+$/a &&
                    $_ >= $MIN_BIG_INT &&
                    $_ <= $MAX_BIG_INT)
             {
@@ -283,7 +283,7 @@ sub time2iso8601
             }
             # Pattern taken from perldata(1)
             elsif (! $FORCE_STRING_ENCODING &&
-                   /^[+-]?(?=\d|[.]\d)\d*(?:[.]\d*)?(?:[Ee](?:[+-]?\d+))?$/x &&
+                   /^[+-]?(?=\d|[.]\d)\d*(?:[.]\d*)?(?:[Ee](?:[+-]?\d+))?$/ax &&
                    $_ > $MIN_DOUBLE &&
                    $_ < $MAX_DOUBLE)
             {


### PR DESCRIPTION
"Being a digit doesn't make you numeric", a colleague told me

In Perl regular expressions, \d matches any digit in any alphabet. But, in the Perl language, something is only numeric if it is made by ASCII digits.

Because of this, the following line gives a warning.

$ perl -Mstrict -Mwarnings -MRPC::XML -e 'my $a="\x{E55}";my $b=RPC::XML::response->new($a)'
Argument "\x{e55}" isn't numeric in numeric ge (>=) at /usr/share/perl5/RPC/XML.pm line 270.

(in Unicode 0E55 is THAI DIGIT FIVE)

This patch adds the modifier a to the regular expressions using \d, so they will only match ASCII digits