### PR TITLE
Fix leak caused by failing to free Expat parser.

### DIFF
--- a/lib/RPC/XML/Client.pm
+++ b/lib/RPC/XML/Client.pm
@@ -406,12 +406,16 @@ sub send_request ## no critic (ProhibitExcessComplexity)
     $response = $self->useragent->request($reqclone, $cb);
     if ($message = $response->headers->header('X-Died'))
     {
+        $parser->release();
+
         # One of the die's was triggered
         return ('CODE' eq ref $self->error_handler) ?
             $self->error_handler->($message) : $message;
     }
     if (! $response->is_success)
     {
+        $parser->release();
+
         $message =  "$me: HTTP server error: " . $response->message;
         return ('CODE' eq ref $self->error_handler) ?
             $self->error_handler->($message) : $message;


### PR DESCRIPTION
We don't want to return from the method until the parser's been freed. We therefore need to call $parser->release() before the return statements caused by request failures.

The documentation for XML::Parser::Expat says it uses data structures with circular references and release is therefore required when not called by higher level calls: https://metacpan.org/pod/distribution/libxml-enno/lib/XML/Parser/Expat.pod#release

I initially thought that we should call parse_done() whether or not parsing succeeded, but it seems that shouldn't be called when the parser has received nothing or invalid XML.

I wonder whether this is related to https://rt.cpan.org/Public/Bug/Display.html?id=41422