### PR TITLE
Added xmlrpc request string as object property

### DIFF
--- a/lib/RPC/XML/Client.pm
+++ b/lib/RPC/XML/Client.pm
@@ -227,6 +227,8 @@ sub send_request ## no critic (ProhibitExcessComplexity)
     my ($me, $message, $response, $reqclone, $content, $can_compress, $value,
         $do_compress, $req_fh, $tmpdir, $com_engine);
 
+    delete $self->{_xmlrcp_request_as_string};
+
     $me = ref($self) . '::send_request';
 
     if (! $req)
@@ -242,6 +244,9 @@ sub send_request ## no critic (ProhibitExcessComplexity)
                 $RPC::XML::ERROR;
         }
     }
+
+    # Add XML-RPC string request as object property
+    utf8::encode( $self->{_xmlrcp_request_as_string} = $req->as_string );
 
     # Start by setting up the request-clone for using in this instance
     $reqclone = $self->request->clone;


### PR DESCRIPTION
Hi,
this PR aims to add XML-RPC request string as object property `_xmlrcp_request_as_string` after the `simple_request()` method call.
In fact, if first argument of the method above isn't a `RPC::XML::request` object itself (so we can use `as_string` method), it seems there isn't a possibility to retrieve the string sent to the server.